### PR TITLE
Create a `NodeProxy` facade to standalone mode

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ task require: :require_bundler do
 end
 
 task console: :require do
-  Bundler.require(:pry)
+  Bundler.require(:default, ENV['RACK_ENV'].to_sym, :pry)
   binding.pry
 end
 

--- a/app.rb
+++ b/app.rb
@@ -212,13 +212,13 @@ FilesSelector = Struct.new(:fields) do
           begin
             GroupProxy.includes(:nodes)
                       .find("#{Figaro.env.remote_cluster!}.#{id}")
-                      .first&.nodes || []
+                      .first&.nodes
           rescue JsonApiClient::Errors::NotFound
-            []
+            # NOOP
           end
         end
       end
-      accum.flatten.uniq(&:id)
+      accum.flatten.reject(&:nil?).uniq(&:name)
     end
   end
 

--- a/app.rb
+++ b/app.rb
@@ -107,7 +107,7 @@ resource :nodes, pkre: PKRE_REGEX do
   end
 
   index do
-    NodeProxy.where(cluster_id: ".#{Figaro.env.remote_cluster!}").all
+    NodeProxy.where(cluster_id: ".#{Figaro.env.remote_cluster!}").to_a
   end
 
   show

--- a/app/proxies.rb
+++ b/app/proxies.rb
@@ -104,6 +104,11 @@ class Topology < Hashie::Trash
       NodeRecord.new(name: name, params: params)
     end
   end
+
+  def find_node(name)
+    @find_node ||= {}
+    @find_node[name] ||= nodes.find { |n| n.name == name }
+  end
 end
 
 module NodeProxy
@@ -114,6 +119,13 @@ module NodeProxy
     # NOTE: There is no cluster in standalone mode. The cluster_id is only
     # accepted so it maintains the interface with Upstream
     Topology::Cache.nodes
+  end
+
+  # Find returns a single element array because that is how NodeRecord.find works
+  register_standalone_methods(:find) do |id|
+    # The ID contains the cluster_id, which is ignored in standalone mode
+    _, name = id.split('.', 2)
+    [Topology::Cache.find_node(name)]
   end
 end
 

--- a/app/proxies.rb
+++ b/app/proxies.rb
@@ -125,7 +125,8 @@ module NodeProxy
   register_standalone_methods(:find) do |id|
     # The ID contains the cluster_id, which is ignored in standalone mode
     _, name = id.split('.', 2)
-    [Topology::Cache.find_node(name)]
+    node = Topology::Cache.find_node(name) || raise(JsonApiClient::Errors::NotFound.new('Standalone Mode'))
+    [node]
   end
 end
 

--- a/app/proxies.rb
+++ b/app/proxies.rb
@@ -126,7 +126,7 @@ module NodeProxy
     # The ID contains the cluster_id, which is ignored in standalone mode
     _, name = id.split('.', 2)
     node = Topology::Cache.find_node(name) || raise(JsonApiClient::Errors::NotFound.new('Standalone Mode'))
-    [node]
+    JsonApiClient::ResultSet.new [node]
   end
 end
 

--- a/spec/controllers/nodes_spec.rb
+++ b/spec/controllers/nodes_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe '/nodes' do
       nodes = parse_last_response_body.data.map(&:id)
       expect(nodes).to contain_exactly(*DemoCluster.new.nodes.map(&:name))
     end
+
+    context 'when in standalone mode' do
+      around(:all) { |e| run_in_standalone(&e) }
+
+      it 'returns the toplogy nodes' do
+        admin_headers
+        get '/nodes'
+        nodes = parse_last_response_body.data.map(&:id)
+        expect(nodes).to contain_exactly(*topology.nodes.keys)
+      end
+    end
   end
 
   describe 'Show#GET' do
@@ -51,6 +62,23 @@ RSpec.describe '/nodes' do
       admin_headers
       get "/nodes/missing"
       expect(last_response).to be_not_found
+    end
+
+    context 'when in standalone mode' do
+      around(:all) { |e| run_in_standalone(&e) }
+
+      it 'returns 404 when the node is missing' do
+        admin_headers
+        get '/nodes/missing'
+        expect(last_response).to be_not_found
+      end
+
+      it 'returns a node' do
+        node = topology.nodes.keys.first
+        admin_headers
+        get "/nodes/#{node}"
+        expect(parse_last_response_body.data.id).to eq(node)
+      end
     end
   end
 end

--- a/spec/fixtures/standalone_cluster.yaml
+++ b/spec/fixtures/standalone_cluster.yaml
@@ -1,0 +1,11 @@
+nodes:
+  standalone1:
+    test_key: standalone1-value
+  standalone2:
+    test_key: standalone2-value
+  standalone3:
+    test_key: standalone3-value
+  standalone4:
+    test_key: standalone4-value
+  standalone5:
+    test_key: standalone5-value

--- a/spec/proxies/node_proxy_spec.rb
+++ b/spec/proxies/node_proxy_spec.rb
@@ -76,10 +76,11 @@ RSpec.describe NodeProxy do
     end
 
     describe '#find' do
-      it 'returns a single element NodeRecord array' do
+      it 'returns a single element NodeRecord JsonApiClient::ResultSet' do
         name = topology.nodes.keys.last
         nodes = described_class.find("noop-cluster.#{name}")
         expect(nodes.length).to be(1)
+        expect(nodes).to be_a(JsonApiClient::ResultSet)
         expect(nodes.first).to be_a(NodeRecord)
         expect(nodes.first.name).to eq(name)
       end

--- a/spec/proxies/node_proxy_spec.rb
+++ b/spec/proxies/node_proxy_spec.rb
@@ -74,6 +74,16 @@ RSpec.describe NodeProxy do
         end
       end
     end
+
+    describe '#find' do
+      it 'returns a single element NodeRecord array' do
+        name = topology.nodes.keys.last
+        nodes = described_class.find("noop-cluster.#{name}")
+        expect(nodes.length).to be(1)
+        expect(nodes.first).to be_a(NodeRecord)
+        expect(nodes.first.name).to eq(name)
+      end
+    end
   end
 end
 

--- a/spec/proxies/node_proxy_spec.rb
+++ b/spec/proxies/node_proxy_spec.rb
@@ -55,6 +55,25 @@ RSpec.describe NodeProxy do
     it 'selects the standalone proxy' do
       expect(described_class.proxy_class).to eq(NodeProxy::Standalone)
     end
+
+    describe '#where' do
+      it 'errors when called with an unrecognised key' do
+        expect do
+          described_class.where(cluster_id: '', some_random_key: true)
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'returns all the topology nodes' do
+        nodes = described_class.where(cluster_id: '')
+        expect(nodes.map(&:name)).to contain_exactly(*topology.nodes.keys)
+      end
+
+      it 'returns an array of NodeRecord' do
+        described_class.where(cluster_id: '').each do |node|
+          expect(node).to be_a(NodeRecord)
+        end
+      end
+    end
   end
 end
 

--- a/spec/proxies/node_proxy_spec.rb
+++ b/spec/proxies/node_proxy_spec.rb
@@ -83,6 +83,12 @@ RSpec.describe NodeProxy do
         expect(nodes.first).to be_a(NodeRecord)
         expect(nodes.first.name).to eq(name)
       end
+
+      it 'errors if the node is missing' do
+        expect do
+          described_class.find('noop-cluster.missing')
+        end.to raise_error(JsonApiClient::Errors::NotFound)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,12 +103,23 @@ RSpec.configure do |c|
     @reset_proxies ||= ObjectSpace.each_object(Module)
                                   .select { |c| c.included_modules.include? HasProxies }
     @reset_proxies.each { |c| c.instance_variable_set(:@proxy_class, nil) }
+    Topology::Cache.instance_variable_set(:@instance, nil)
   end
 
   def run_in_standalone
     reset_proxies
-    ClimateControl.modify(remote_url: nil) { yield if block_given? }
+    ClimateControl.modify(remote_url: nil, topology_config: topology_path) do
+      yield if block_given?
+    end
     reset_proxies
+  end
+
+  def topology_path
+    File.expand_path('fixtures/standalone_cluster.yaml', __dir__)
+  end
+
+  def topology
+    Hashie::Mash.load(topology_path)
   end
 
   def admin_headers


### PR DESCRIPTION
This stubs out the calls to `NodeRecord` so it can be used independently from `nodeattr-server`